### PR TITLE
docs: simplify issue templates config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -17,18 +17,3 @@ body:
       description: Décrivez clairement le problème rencontré
     validations:
       required: true
-
-  - type: input
-    id: steps
-    attributes:
-      label: Étapes pour reproduire
-      description: Listez les étapes pour reproduire le bug
-      placeholder: "1. ...\n2. ...\n3. ..."
-    validations:
-      required: true
-
-  - type: textarea
-    id: expected
-    attributes:
-      label: Résultat attendu
-      description: Décrivez ce que vous attendiez

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,6 @@
-# Configuration des templates d'issues pour FINESS
+# Configuration des templates d'issues pour FiNESS
 blank_issues_enabled: false
 contact_links:
-  - name: FAQ FINESS
+  - name: FAQ FiNESS
     url: https://github.com/ansforge/finess/blob/main/FAQ.md
     about: Avant de créer une issue, consultez la FAQ pour voir si la réponse existe déjà.
-  - name: Support / Questions
-    url: https://github.com/ansforge/finess/issues
-    about: Pour toute question ou problème, créez une issue via nos templates.


### PR DESCRIPTION
Simplification de la configuration des templates d’issues :

- Suppression du lien vers les issues générales pour éviter la redirection inutile.
- Conservation uniquement du lien vers la FAQ FINESS.
- Désactivation des issues vierges via `blank_issues_enabled: false`.
