### PR TITLE
fix: remove aaEnseignementReguleeId from schema

### DIFF
--- a/flux/out/data.gouv/activite/schema/schema-activites-v1.json
+++ b/flux/out/data.gouv/activite/schema/schema-activites-v1.json
@@ -699,7 +699,6 @@
         }
       },
       "required": [
-        "aaEnseignementReguleeId",
         "activiteAeId",
         "typeActiviteAER"
       ],


### PR DESCRIPTION
Removed 'aaEnseignementReguleeId' from required fields.